### PR TITLE
[#2] Implement not-html-error to be used in communication value-objects

### DIFF
--- a/src/core/0.domain/errors/not-html-error.ts
+++ b/src/core/0.domain/errors/not-html-error.ts
@@ -1,0 +1,11 @@
+import { DomainError } from '@/core/0.domain/base/domain-error'
+
+export class NotHtmlError extends DomainError {
+  constructor (field: string, input: string) {
+    super({
+      message: 'should be a valid html',
+      field,
+      input
+    })
+  }
+}

--- a/test/core/0.domain/errors/not-html-error.unit.test.ts
+++ b/test/core/0.domain/errors/not-html-error.unit.test.ts
@@ -1,0 +1,39 @@
+import { NotHtmlError } from '@/core/0.domain/errors/not-html-error'
+
+type SutTypes = {
+  sut: typeof NotHtmlError
+}
+
+const makeSut = (): SutTypes => {
+  const sut = NotHtmlError
+
+  return { sut }
+}
+
+describe('NotHtmlError', () => {
+  describe('success', () => {
+    it('returns a NotHtmlError', () => {
+      const { sut } = makeSut()
+      const field = 'any_field'
+      const input = 'invalid_html'
+
+      const result = new sut(field, input)
+
+      expect(result).toBeInstanceOf(NotHtmlError)
+    })
+
+    it('returns props with correct values when input is invalid', () => {
+      const { sut } = makeSut()
+      const field = 'any_field'
+      const input = 'invalid_html'
+
+      const result = new sut(field, input)
+
+      expect(result.props).toEqual({
+        field: 'any_field',
+        input: 'invalid_html',
+        message: 'should be a valid html'
+      })
+    })
+  })
+})


### PR DESCRIPTION
### Issue:
#2

### Description:
- Add `not-html-error` to `core/0.domain/errors`