### PR TITLE
[#1] Implement value-objects of communication module

### DIFF
--- a/src/core/0.domain/validators/email-validator.ts
+++ b/src/core/0.domain/validators/email-validator.ts
@@ -1,10 +1,9 @@
-import { DomainError } from '@/core/0.domain/base/domain-error'
 import { Validator } from '@/core/0.domain/base/validator'
 import { InvalidEmailError } from '@/core/0.domain/errors/invalid-email-error'
 import { Either, left, right } from '@/core/0.domain/utils/either'
 
 export class EmailValidator extends Validator<null> {
-  validate (field: string, input: string): Either<DomainError, void> {
+  validate (field: string, input: string): Either<InvalidEmailError, void> {
     const tester = /^[-!#$%&'*+/0-9=?A-Z^_a-z`{|}~](\.?[-!#$%&'*+/0-9=?A-Z^_a-z`{|}~])*@[a-zA-Z0-9](-*\.?[a-zA-Z0-9])*\.[a-zA-Z](-?[a-zA-Z0-9])+$/
 
     if (!tester.test(input)) {

--- a/src/core/0.domain/validators/not-html-validator.ts
+++ b/src/core/0.domain/validators/not-html-validator.ts
@@ -1,0 +1,15 @@
+import { Validator } from '@/core/0.domain/base/validator'
+import { NotHtmlError } from '@/core/0.domain/errors/not-html-error'
+import { Either, left, right } from '@/core/0.domain/utils/either'
+
+export class NotHtmlValidator extends Validator<null> {
+  validate (field: string, input: string): Either<NotHtmlError, void> {
+    const tester = /<([a-zA-Z]+)(\s*|>).*(>|\/\1>)/
+
+    if (!tester.test(input)) {
+      return left(new NotHtmlError(field, input))
+    }
+
+    return right()
+  }
+}

--- a/src/modules/communication/0.domain/value-objects/from.ts
+++ b/src/modules/communication/0.domain/value-objects/from.ts
@@ -1,0 +1,18 @@
+import { DomainError } from '@/core/0.domain/base/domain-error'
+import { ValueObject } from '@/core/0.domain/base/value-object'
+import { Either } from '@/core/0.domain/utils/either'
+import { EmailValidator } from '@/core/0.domain/validators/email-validator'
+import { MaxLengthValidator } from '@/core/0.domain/validators/max-length-validator'
+import { MinLengthValidator } from '@/core/0.domain/validators/min-length-validator'
+
+export class From extends ValueObject<string> {
+  static create (input: string): Either<DomainError[], From> {
+    const validOrError = this.validate(input, [
+      new MinLengthValidator({ minLength: 12 }),
+      new MaxLengthValidator({ maxLength: 64 }),
+      new EmailValidator()
+    ])
+
+    return validOrError.applyOnRight(() => new From(input))
+  }
+}

--- a/src/modules/communication/0.domain/value-objects/html.ts
+++ b/src/modules/communication/0.domain/value-objects/html.ts
@@ -1,0 +1,14 @@
+import { DomainError } from '@/core/0.domain/base/domain-error'
+import { ValueObject } from '@/core/0.domain/base/value-object'
+import { Either } from '@/core/0.domain/utils/either'
+import { NotHtmlValidator } from '@/core/0.domain/validators/not-html-validator'
+
+export class Html extends ValueObject<string> {
+  static create (input: string): Either<DomainError[], Html> {
+    const validOrError = this.validate(input, [
+      new NotHtmlValidator()
+    ])
+
+    return validOrError.applyOnRight(() => new Html(input))
+  }
+}

--- a/src/modules/communication/0.domain/value-objects/subject.ts
+++ b/src/modules/communication/0.domain/value-objects/subject.ts
@@ -1,0 +1,16 @@
+import { DomainError } from '@/core/0.domain/base/domain-error'
+import { ValueObject } from '@/core/0.domain/base/value-object'
+import { Either } from '@/core/0.domain/utils/either'
+import { MaxLengthValidator } from '@/core/0.domain/validators/max-length-validator'
+import { MinLengthValidator } from '@/core/0.domain/validators/min-length-validator'
+
+export class Subject extends ValueObject<string> {
+  static create (input: string): Either<DomainError[], Subject> {
+    const validOrError = this.validate(input, [
+      new MinLengthValidator({ minLength: 3 }),
+      new MaxLengthValidator({ maxLength: 64 })
+    ])
+
+    return validOrError.applyOnRight(() => new Subject(input))
+  }
+}

--- a/src/modules/communication/0.domain/value-objects/text.ts
+++ b/src/modules/communication/0.domain/value-objects/text.ts
@@ -1,0 +1,14 @@
+import { DomainError } from '@/core/0.domain/base/domain-error'
+import { ValueObject } from '@/core/0.domain/base/value-object'
+import { Either } from '@/core/0.domain/utils/either'
+import { MinLengthValidator } from '@/core/0.domain/validators/min-length-validator'
+
+export class Text extends ValueObject<string> {
+  static create (input: string): Either<DomainError[], Text> {
+    const validOrError = this.validate(input, [
+      new MinLengthValidator({ minLength: 6 })
+    ])
+
+    return validOrError.applyOnRight(() => new Text(input))
+  }
+}

--- a/src/modules/communication/0.domain/value-objects/to.ts
+++ b/src/modules/communication/0.domain/value-objects/to.ts
@@ -1,0 +1,18 @@
+import { DomainError } from '@/core/0.domain/base/domain-error'
+import { ValueObject } from '@/core/0.domain/base/value-object'
+import { Either } from '@/core/0.domain/utils/either'
+import { EmailValidator } from '@/core/0.domain/validators/email-validator'
+import { MaxLengthValidator } from '@/core/0.domain/validators/max-length-validator'
+import { MinLengthValidator } from '@/core/0.domain/validators/min-length-validator'
+
+export class To extends ValueObject<string> {
+  static create (input: string): Either<DomainError[], To> {
+    const validOrError = this.validate(input, [
+      new MinLengthValidator({ minLength: 12 }),
+      new MaxLengthValidator({ maxLength: 64 }),
+      new EmailValidator()
+    ])
+
+    return validOrError.applyOnRight(() => new To(input))
+  }
+}

--- a/src/modules/communication/1.application/handlers/user-created-handler.ts
+++ b/src/modules/communication/1.application/handlers/user-created-handler.ts
@@ -1,0 +1,18 @@
+import { Handler } from '@/core/0.domain/base/handler'
+import { DomainEvents } from '@/core/0.domain/events/domain-events'
+import { UserCreatedEvent } from '@/user/0.domain/events/user-created-event'
+
+export class UserCreatedHandler extends Handler {
+  constructor () {
+    super()
+    this.setupSubscriptions()
+  }
+
+  setupSubscriptions (): void {
+    DomainEvents.register(this.onUserCreatedEvent.bind(this), UserCreatedEvent.name)
+  }
+
+  private async onUserCreatedEvent (event: UserCreatedEvent): Promise<void> {
+    console.log('event >>>', event)
+  }
+}

--- a/src/modules/communication/4.main/setup/handlers.ts
+++ b/src/modules/communication/4.main/setup/handlers.ts
@@ -1,0 +1,5 @@
+import { UserCreatedHandler } from '@/communication/1.application/handlers/user-created-handler'
+
+export const setCommunicationHandlers = (): void => {
+  new UserCreatedHandler()
+}

--- a/test/core/0.domain/validators/not-html-validator.unit.test.ts
+++ b/test/core/0.domain/validators/not-html-validator.unit.test.ts
@@ -1,0 +1,48 @@
+import { NotHtmlError } from '@/core/0.domain/errors/not-html-error'
+import { NotHtmlValidator } from '@/core/0.domain/validators/not-html-validator'
+
+type SutTypes = {
+  sut: NotHtmlValidator
+}
+
+const makeSut = (): SutTypes => {
+  const sut = new NotHtmlValidator()
+
+  return { sut }
+}
+
+describe('NotHtmlValidator', () => {
+  describe('success', () => {
+    it('returns Right when input is a valid html', () => {
+      const { sut } = makeSut()
+      const field = 'any_field'
+      const input = '<html>any_text</html>'
+
+      const result = sut.validate(field, input)
+
+      expect(result.isRight()).toBe(true)
+    })
+  })
+
+  describe('failure', () => {
+    it('returns Left when input is an invalid html', () => {
+      const { sut } = makeSut()
+      const field = 'any_field'
+      const input = ''
+
+      const result = sut.validate(field, input)
+
+      expect(result.isLeft()).toBe(true)
+    })
+
+    it('returns NotHtmlError when validation fails', () => {
+      const { sut } = makeSut()
+      const field = 'any_field'
+      const input = ''
+
+      const result = sut.validate(field, input)
+
+      expect(result.value).toBeInstanceOf(NotHtmlError)
+    })
+  })
+})

--- a/test/modules/communication/0.domain/value-objects/from.unit.test.ts
+++ b/test/modules/communication/0.domain/value-objects/from.unit.test.ts
@@ -1,0 +1,56 @@
+import { From } from '@/communication/0.domain/value-objects/from'
+import { InvalidEmailError } from '@/core/0.domain/errors/invalid-email-error'
+import { MaxLengthError } from '@/core/0.domain/errors/max-length-error'
+import { MinLengthError } from '@/core/0.domain/errors/min-length-error'
+
+type SutTypes = {
+  sut: typeof From
+}
+
+const makeSut = (): SutTypes => {
+  const sut = From
+
+  return { sut }
+}
+
+describe('From', () => {
+  describe('success', () => {
+    it('returns a From when input is valid', () => {
+      const { sut } = makeSut()
+      const input = 'any@mail.com'
+
+      const result = sut.create(input)
+
+      expect(result.value).toBeInstanceOf(From)
+    })
+  })
+
+  describe('failure', () => {
+    it('returns MinLengthError when input.length is lower than minLength', () => {
+      const { sut } = makeSut()
+      const input = 'a@b.com'
+
+      const result = sut.create(input)
+
+      expect(result.value[0]).toBeInstanceOf(MinLengthError)
+    })
+
+    it('returns MaxLengthError when input.length is higher than maxLength', () => {
+      const { sut } = makeSut()
+      const input = 'input_that_exceeds_from_max_length_of_sixty_four_characters@mail.com'
+
+      const result = sut.create(input)
+
+      expect(result.value[0]).toBeInstanceOf(MaxLengthError)
+    })
+
+    it('returns InvalidEmailError when input is not an e-mail', () => {
+      const { sut } = makeSut()
+      const input = 'invalid_email'
+
+      const result = sut.create(input)
+
+      expect(result.value[0]).toBeInstanceOf(InvalidEmailError)
+    })
+  })
+})

--- a/test/modules/communication/0.domain/value-objects/html.unit.test.ts
+++ b/test/modules/communication/0.domain/value-objects/html.unit.test.ts
@@ -1,0 +1,36 @@
+import { Html } from '@/communication/0.domain/value-objects/html'
+import { NotHtmlError } from '@/core/0.domain/errors/not-html-error'
+
+type SutTypes = {
+  sut: typeof Html
+}
+
+const makeSut = (): SutTypes => {
+  const sut = Html
+
+  return { sut }
+}
+
+describe('Html', () => {
+  describe('success', () => {
+    it('returns a Html when input is valid', () => {
+      const { sut } = makeSut()
+      const input = '<html>any_text</html>'
+
+      const result = sut.create(input)
+
+      expect(result.value).toBeInstanceOf(Html)
+    })
+  })
+
+  describe('failure', () => {
+    it('returns NotHtmlError when input is an invalid html text', () => {
+      const { sut } = makeSut()
+      const input = null
+
+      const result = sut.create(input)
+
+      expect(result.value[0]).toBeInstanceOf(NotHtmlError)
+    })
+  })
+})

--- a/test/modules/communication/0.domain/value-objects/subject.unit.test.ts
+++ b/test/modules/communication/0.domain/value-objects/subject.unit.test.ts
@@ -1,0 +1,46 @@
+import { Subject } from '@/communication/0.domain/value-objects/subject'
+import { MaxLengthError } from '@/core/0.domain/errors/max-length-error'
+import { MinLengthError } from '@/core/0.domain/errors/min-length-error'
+
+type SutTypes = {
+  sut: typeof Subject
+}
+
+const makeSut = (): SutTypes => {
+  const sut = Subject
+
+  return { sut }
+}
+
+describe('Subject', () => {
+  describe('success', () => {
+    it('returns a Subject when input is valid', () => {
+      const { sut } = makeSut()
+      const input = 'any_subject'
+
+      const result = sut.create(input)
+
+      expect(result.value).toBeInstanceOf(Subject)
+    })
+  })
+
+  describe('failure', () => {
+    it('returns MinLengthError when input.length is lower than minLength', () => {
+      const { sut } = makeSut()
+      const input = null
+
+      const result = sut.create(input)
+
+      expect(result.value[0]).toBeInstanceOf(MinLengthError)
+    })
+
+    it('returns MaxLengthError when input.length is higher than maxLength', () => {
+      const { sut } = makeSut()
+      const input = 'input_that_exceeds_subject_max_length_of_sixty_four_characters___'
+
+      const result = sut.create(input)
+
+      expect(result.value[0]).toBeInstanceOf(MaxLengthError)
+    })
+  })
+})

--- a/test/modules/communication/0.domain/value-objects/text.unit.test.ts
+++ b/test/modules/communication/0.domain/value-objects/text.unit.test.ts
@@ -1,0 +1,36 @@
+import { Text } from '@/communication/0.domain/value-objects/text'
+import { MinLengthError } from '@/core/0.domain/errors/min-length-error'
+
+type SutTypes = {
+  sut: typeof Text
+}
+
+const makeSut = (): SutTypes => {
+  const sut = Text
+
+  return { sut }
+}
+
+describe('Text', () => {
+  describe('success', () => {
+    it('returns a Text when input is valid', () => {
+      const { sut } = makeSut()
+      const input = 'any_text'
+
+      const result = sut.create(input)
+
+      expect(result.value).toBeInstanceOf(Text)
+    })
+  })
+
+  describe('failure', () => {
+    it('returns MinLengthError when input.length is lower than minLength', () => {
+      const { sut } = makeSut()
+      const input = null
+
+      const result = sut.create(input)
+
+      expect(result.value[0]).toBeInstanceOf(MinLengthError)
+    })
+  })
+})

--- a/test/modules/communication/0.domain/value-objects/to.unit.test.ts
+++ b/test/modules/communication/0.domain/value-objects/to.unit.test.ts
@@ -1,0 +1,56 @@
+import { To } from '@/communication/0.domain/value-objects/to'
+import { InvalidEmailError } from '@/core/0.domain/errors/invalid-email-error'
+import { MaxLengthError } from '@/core/0.domain/errors/max-length-error'
+import { MinLengthError } from '@/core/0.domain/errors/min-length-error'
+
+type SutTypes = {
+  sut: typeof To
+}
+
+const makeSut = (): SutTypes => {
+  const sut = To
+
+  return { sut }
+}
+
+describe('To', () => {
+  describe('success', () => {
+    it('returns a To when input is valid', () => {
+      const { sut } = makeSut()
+      const input = 'any@mail.com'
+
+      const result = sut.create(input)
+
+      expect(result.value).toBeInstanceOf(To)
+    })
+  })
+
+  describe('failure', () => {
+    it('returns MinLengthError when input.length is lower than minLength', () => {
+      const { sut } = makeSut()
+      const input = 'a@b.com'
+
+      const result = sut.create(input)
+
+      expect(result.value[0]).toBeInstanceOf(MinLengthError)
+    })
+
+    it('returns MaxLengthError when input.length is higher than maxLength', () => {
+      const { sut } = makeSut()
+      const input = 'input_that_exceeds_to_max_length_of_sixty_four_characters@mail.com'
+
+      const result = sut.create(input)
+
+      expect(result.value[0]).toBeInstanceOf(MaxLengthError)
+    })
+
+    it('returns InvalidEmailError when input is not an e-mail', () => {
+      const { sut } = makeSut()
+      const input = 'invalid_email'
+
+      const result = sut.create(input)
+
+      expect(result.value[0]).toBeInstanceOf(InvalidEmailError)
+    })
+  })
+})


### PR DESCRIPTION
### Issue:
https://github.com/leal32b/webapi-nodejs/issues/1

### Description:
- Add `not-html-validator` to `core/0.domain/validators`
- Add `value-objects` for `communication` module