### PR TITLE
[#6] implement send email validation email use case

### DIFF
--- a/src/modules/communication/1.application/email/email-sender.ts
+++ b/src/modules/communication/1.application/email/email-sender.ts
@@ -1,0 +1,7 @@
+import { EmailEntity } from '@/communication/0.domain/entities/email-entity'
+import { DomainError } from '@/core/0.domain/base/domain-error'
+import { Either } from '@/core/0.domain/utils/either'
+
+export interface EmailSender {
+  send: (email: EmailEntity) => Promise<Either<DomainError, void>>
+}

--- a/src/modules/communication/1.application/use-cases/send-email-validation-email-use-case.ts
+++ b/src/modules/communication/1.application/use-cases/send-email-validation-email-use-case.ts
@@ -1,0 +1,45 @@
+import { EmailEntity } from '@/communication/0.domain/entities/email-entity'
+import { EmailSender } from '@/communication/1.application/email/email-sender'
+import { DomainError } from '@/core/0.domain/base/domain-error'
+import { Either, left, right } from '@/core/0.domain/utils/either'
+import { UseCase } from '@/core/1.application/base/use-case'
+
+export type SendEmailValidationEmailData = {
+  recipientEmail: string
+  token: string
+}
+
+export type SendEmailValidationEmailResultDTO = {
+  message: string
+}
+
+export class SendEmailValidationEmailUseCase extends UseCase<SendEmailValidationEmailData, SendEmailValidationEmailResultDTO> {
+  constructor (private readonly props: {
+    emailSender: EmailSender
+  }) { super() }
+
+  async execute (sendEmailValidationEmailData: SendEmailValidationEmailData): Promise<Either<DomainError[], SendEmailValidationEmailResultDTO>> {
+    const { emailSender } = this.props
+    const { recipientEmail, token } = sendEmailValidationEmailData
+
+    const emailEntityOrError = EmailEntity.create({
+      from: 'from@mail.com',
+      subject: 'any_subject',
+      to: recipientEmail,
+      html: `<html>token: ${token}</html>`
+    })
+
+    if (emailEntityOrError.isLeft()) {
+      return left(emailEntityOrError.value)
+    }
+
+    const emailEntity = emailEntityOrError.value
+    const result = await emailSender.send(emailEntity)
+
+    if (result.isLeft()) {
+      return left([result.value])
+    }
+
+    return right({ message: 'e-mail validation e-mail sent successfully' })
+  }
+}

--- a/test/modules/communication/1.application/use-cases/send-email-validation-email-use-case.unit.test.ts
+++ b/test/modules/communication/1.application/use-cases/send-email-validation-email-use-case.unit.test.ts
@@ -1,0 +1,89 @@
+import { EmailEntity } from '@/communication/0.domain/entities/email-entity'
+import { EmailSender } from '@/communication/1.application/email/email-sender'
+import { SendEmailValidationEmailData, SendEmailValidationEmailUseCase } from '@/communication/1.application/use-cases/send-email-validation-email-use-case'
+import { DomainError } from '@/core/0.domain/base/domain-error'
+import { Either, left, right } from '@/core/0.domain/utils/either'
+
+const makeErrorFake = (): DomainError => {
+  class ErrorFake extends DomainError {
+    constructor () {
+      super({ message: 'any_message' })
+    }
+  }
+
+  return new ErrorFake()
+}
+
+const makeSendEmailValidationEmailDataFake = (): SendEmailValidationEmailData => ({
+  recipientEmail: 'recipient@mail.com',
+  token: 'any_token'
+})
+
+const makeEmailSenderStub = (): EmailSender => ({
+  send: jest.fn(async (): Promise<Either<DomainError, void>> => right())
+})
+
+type SutTypes = {
+  sut: SendEmailValidationEmailUseCase
+  emailSender: EmailSender
+  errorFake: DomainError
+  sendEmailValidationEmailDataFake: SendEmailValidationEmailData
+}
+
+const makeSut = (): SutTypes => {
+  const doubles = {
+    errorFake: makeErrorFake(),
+    sendEmailValidationEmailDataFake: makeSendEmailValidationEmailDataFake()
+  }
+  const params = {
+    emailSender: makeEmailSenderStub()
+  }
+
+  const sut = new SendEmailValidationEmailUseCase(params)
+
+  return { sut, ...params, ...doubles }
+}
+
+describe('SendEmailValidationEmailUseCase', () => {
+  describe('success', () => {
+    it('calls EmailSender.send with correct param', async () => {
+      const { sut, emailSender, sendEmailValidationEmailDataFake } = makeSut()
+
+      await sut.execute(sendEmailValidationEmailDataFake)
+
+      expect(emailSender.send).toHaveBeenCalledWith(expect.any(EmailEntity))
+    })
+
+    it('returns a message', async () => {
+      const { sut, sendEmailValidationEmailDataFake } = makeSut()
+
+      const result = await sut.execute(sendEmailValidationEmailDataFake)
+
+      expect(result.value).toEqual({
+        message: 'e-mail validation e-mail sent successfully'
+      })
+    })
+  })
+
+  describe('failure', () => {
+    it('returns an Error when EmailEntity.create fails', async () => {
+      const { sut, sendEmailValidationEmailDataFake } = makeSut()
+
+      const result = await sut.execute({
+        ...sendEmailValidationEmailDataFake,
+        recipientEmail: 'invalid_email'
+      })
+
+      expect(result.value[0]).toBeInstanceOf(DomainError)
+    })
+
+    it('returns an Error when EmailSender.send fails', async () => {
+      const { sut, emailSender, errorFake, sendEmailValidationEmailDataFake } = makeSut()
+      jest.spyOn(emailSender, 'send').mockResolvedValueOnce(left(errorFake))
+
+      const result = await sut.execute(sendEmailValidationEmailDataFake)
+
+      expect(result.value[0]).toBeInstanceOf(DomainError)
+    })
+  })
+})

--- a/test/modules/user/1.application/use-cases/authenticate-user-use-case.unit.test.ts
+++ b/test/modules/user/1.application/use-cases/authenticate-user-use-case.unit.test.ts
@@ -137,7 +137,7 @@ describe('AuthenticateUserUseCase', () => {
 
       const result = await sut.execute(authenticateUserDataFake)
 
-      expect(result.value[0]).toEqual(errorFake)
+      expect(result.value[0]).toBeInstanceOf(DomainError)
     })
 
     it('returns NotFoundError when userRepository.readByEmail returns null', async () => {
@@ -155,7 +155,7 @@ describe('AuthenticateUserUseCase', () => {
 
       const result = await sut.execute(authenticateUserDataFake)
 
-      expect(result.value[0]).toEqual(errorFake)
+      expect(result.value[0]).toBeInstanceOf(DomainError)
     })
 
     it('returns an Error when Encrypter.encrypt fails', async () => {
@@ -164,7 +164,7 @@ describe('AuthenticateUserUseCase', () => {
 
       const result = await sut.execute(authenticateUserDataFake)
 
-      expect(result.value[0]).toEqual(errorFake)
+      expect(result.value[0]).toBeInstanceOf(DomainError)
     })
 
     it('returns an Error when Token.create fails', async () => {
@@ -174,7 +174,7 @@ describe('AuthenticateUserUseCase', () => {
 
       const result = await sut.execute(authenticateUserDataFake)
 
-      expect(result.value[0]).toEqual(errorFake)
+      expect(result.value[0]).toBeInstanceOf(DomainError)
     })
 
     it('returns an Error when UserRepository.update fails', async () => {
@@ -183,7 +183,7 @@ describe('AuthenticateUserUseCase', () => {
 
       const result = await sut.execute(authenticateUserDataFake)
 
-      expect(result.value[0]).toEqual(errorFake)
+      expect(result.value[0]).toBeInstanceOf(DomainError)
     })
   })
 })

--- a/test/modules/user/1.application/use-cases/authenticate-user-use-case.unit.test.ts
+++ b/test/modules/user/1.application/use-cases/authenticate-user-use-case.unit.test.ts
@@ -115,17 +115,7 @@ describe('AuthenticateUserUseCase', () => {
 
       await sut.execute(authenticateUserDataFake)
 
-      expect(userRepository.update).toHaveBeenCalledWith({
-        props: {
-          email: expect.any(Object),
-          emailConfirmed: expect.any(Object),
-          id: expect.any(Object),
-          name: expect.any(Object),
-          password: expect.any(Object),
-          token: expect.any(Object)
-        },
-        _events: expect.any(Array)
-      })
+      expect(userRepository.update).toHaveBeenCalledWith(expect.any(UserAggregate))
     })
 
     it('returns a message and the accessToken', async () => {

--- a/test/modules/user/1.application/use-cases/change-password-use-case.unit.test.ts
+++ b/test/modules/user/1.application/use-cases/change-password-use-case.unit.test.ts
@@ -89,17 +89,7 @@ describe('AuthenticateUserUseCase', () => {
 
       await sut.execute(changePasswordDataFake)
 
-      expect(userRepository.update).toHaveBeenCalledWith({
-        props: {
-          email: expect.any(Object),
-          emailConfirmed: expect.any(Object),
-          id: expect.any(Object),
-          name: expect.any(Object),
-          password: expect.any(Object),
-          token: expect.any(Object)
-        },
-        _events: expect.any(Array)
-      })
+      expect(userRepository.update).toHaveBeenCalledWith(expect.any(UserAggregate))
     })
 
     it('returns a message', async () => {

--- a/test/modules/user/1.application/use-cases/change-password-use-case.unit.test.ts
+++ b/test/modules/user/1.application/use-cases/change-password-use-case.unit.test.ts
@@ -118,7 +118,7 @@ describe('AuthenticateUserUseCase', () => {
 
       const result = await sut.execute(changePasswordDataFake)
 
-      expect(result.value[0]).toEqual(errorFake)
+      expect(result.value[0]).toBeInstanceOf(DomainError)
     })
 
     it('returns NotFoundError when userRepository.readById returns null', async () => {
@@ -136,7 +136,7 @@ describe('AuthenticateUserUseCase', () => {
 
       const result = await sut.execute(changePasswordDataFake)
 
-      expect(result.value[0]).toEqual(errorFake)
+      expect(result.value[0]).toBeInstanceOf(DomainError)
     })
 
     it('returns an Error when Password.create fails', async () => {
@@ -146,7 +146,7 @@ describe('AuthenticateUserUseCase', () => {
 
       const result = await sut.execute(changePasswordDataFake)
 
-      expect(result.value[0]).toEqual(errorFake)
+      expect(result.value[0]).toBeInstanceOf(DomainError)
     })
 
     it('returns an Error when UserRepository.update fails', async () => {
@@ -155,7 +155,7 @@ describe('AuthenticateUserUseCase', () => {
 
       const result = await sut.execute(changePasswordDataFake)
 
-      expect(result.value[0]).toEqual(errorFake)
+      expect(result.value[0]).toBeInstanceOf(DomainError)
     })
   })
 })

--- a/test/modules/user/1.application/use-cases/create-user-use-case.unit.test.ts
+++ b/test/modules/user/1.application/use-cases/create-user-use-case.unit.test.ts
@@ -179,7 +179,7 @@ describe('CreateUserUseCase', () => {
       expect(result.value[0]).toEqual(errorFake)
     })
 
-    it('returns an Error when User.create fails', async () => {
+    it('returns an Error when UserAggregate.create fails', async () => {
       const { sut, createUserDataFake } = makeSut()
 
       const result = await sut.execute({ ...createUserDataFake, email: 'invalid_email' })

--- a/test/modules/user/1.application/use-cases/create-user-use-case.unit.test.ts
+++ b/test/modules/user/1.application/use-cases/create-user-use-case.unit.test.ts
@@ -135,7 +135,7 @@ describe('CreateUserUseCase', () => {
 
       const result = await sut.execute(createUserDataFake)
 
-      expect(result.value[0]).toEqual(errorFake)
+      expect(result.value[0]).toBeInstanceOf(DomainError)
     })
 
     it('returns EmailTakenError when email is already in use', async () => {
@@ -167,7 +167,7 @@ describe('CreateUserUseCase', () => {
 
       const result = await sut.execute(createUserDataFake)
 
-      expect(result.value[0]).toEqual(errorFake)
+      expect(result.value[0]).toBeInstanceOf(DomainError)
     })
 
     it('returns an Error when Encrypter.encrypt fails', async () => {
@@ -176,7 +176,7 @@ describe('CreateUserUseCase', () => {
 
       const result = await sut.execute(createUserDataFake)
 
-      expect(result.value[0]).toEqual(errorFake)
+      expect(result.value[0]).toBeInstanceOf(DomainError)
     })
 
     it('returns an Error when UserAggregate.create fails', async () => {
@@ -193,7 +193,7 @@ describe('CreateUserUseCase', () => {
 
       const result = await sut.execute(createUserDataFake)
 
-      expect(result.value[0]).toEqual(errorFake)
+      expect(result.value[0]).toBeInstanceOf(DomainError)
     })
   })
 })

--- a/test/modules/user/1.application/use-cases/create-user-use-case.unit.test.ts
+++ b/test/modules/user/1.application/use-cases/create-user-use-case.unit.test.ts
@@ -104,16 +104,7 @@ describe('CreateUserUseCase', () => {
 
       await sut.execute(createUserDataFake)
 
-      expect(userRepository.create).toHaveBeenCalledWith(
-        expect.objectContaining({
-          email: expect.any(Object),
-          emailConfirmed: expect.any(Object),
-          id: expect.any(Object),
-          name: expect.any(Object),
-          password: expect.any(Object),
-          token: expect.any(Object)
-        })
-      )
+      expect(userRepository.create).toHaveBeenCalledWith(expect.any(UserAggregate))
     })
 
     it('calls DomainEvents.dispatchEventsForAggregate with correct params', async () => {


### PR DESCRIPTION
### Issue:
https://github.com/leal32b/webapi-nodejs/pull/4

### Description:
- TDD: create tests
- Define `email-sender` interface in `modules/communication/1.application/email`
- Implement `send-email-validation-email-use-case` in `modules/communication/1.application/use-cases`